### PR TITLE
Lisätty tulojen lisäyslomake frontendiin

### DIFF
--- a/frontend/src/api/tuloApi.js
+++ b/frontend/src/api/tuloApi.js
@@ -1,0 +1,17 @@
+const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8080";
+
+export async function haeKategoriat() {
+  const res = await fetch(`${API_BASE}/api/kategoriat`);
+  if (!res.ok) throw new Error((await res.text()) || `Virhe: ${res.status}`);
+  return res.json();
+}
+
+export async function lisaaTulo(data) {
+  const res = await fetch(`${API_BASE}/api/tulot`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error((await res.text()) || `Virhe: ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/sivut/LisaaTapahtuma.jsx
+++ b/frontend/src/sivut/LisaaTapahtuma.jsx
@@ -1,8 +1,118 @@
+import { useState, useEffect } from "react";
+import { haeKategoriat, lisaaTulo } from "../api/tuloApi";
+
+function tanaan() {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export default function LisaaTapahtuma() {
-    return (
-        <div>
-            <h1>Lisää tapahtuma</h1>
-            <p>Täällä on lomake uuden tulon/menon lisäämiseen.</p>
-        </div>
-    );
+  const [kuvaus, setKuvaus] = useState("");
+  const [maara, setMaara] = useState("");
+  const [pvm, setPvm] = useState(tanaan());
+  const [kategoriaId, setKategoriaId] = useState("");
+  const [kategoriat, setKategoriat] = useState([]);
+  const [lataaKategoriat, setLataaKategoriat] = useState(false);
+  const [lahettaa, setLahettaa] = useState(false);
+  const [virhe, setVirhe] = useState("");
+  const [onnistui, setOnnistui] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLataaKategoriat(true);
+    haeKategoriat()
+      .then((data) => { if (!cancelled) setKategoriat(data); })
+      .catch(() => { if (!cancelled) setVirhe("Kategorioiden haku epäonnistui."); })
+      .finally(() => { if (!cancelled) setLataaKategoriat(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setVirhe("");
+    setOnnistui(false);
+
+    const maaraNum = parseFloat(maara);
+    if (!kuvaus.trim()) { setVirhe("Kuvaus on pakollinen."); return; }
+    if (isNaN(maaraNum) || maaraNum <= 0) { setVirhe("Määrän on oltava positiivinen luku."); return; }
+
+    setLahettaa(true);
+    try {
+      await lisaaTulo({
+        kuvaus: kuvaus.trim(),
+        maara: maaraNum,
+        pvm,
+        kategoria: kategoriaId ? { id: Number(kategoriaId) } : null,
+      });
+      setOnnistui(true);
+      setKuvaus("");
+      setMaara("");
+      setPvm(tanaan());
+      setKategoriaId("");
+    } catch (err) {
+      setVirhe(err.message || "Tallennus epäonnistui.");
+    } finally {
+      setLahettaa(false);
+    }
+  }
+
+  return (
+    <div>
+      <h1>Lisää tulo</h1>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4 }}>Kuvaus</label>
+            <input
+              type="text"
+              value={kuvaus}
+              onChange={(e) => setKuvaus(e.target.value)}
+              style={{ width: "100%" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4 }}>Määrä (€)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={maara}
+              onChange={(e) => setMaara(e.target.value)}
+              style={{ width: "100%" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", marginBottom: 4 }}>Päivämäärä</label>
+            <input
+              type="date"
+              value={pvm}
+              onChange={(e) => setPvm(e.target.value)}
+            />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "block", marginBottom: 4 }}>Kategoria</label>
+            <select
+              value={kategoriaId}
+              onChange={(e) => setKategoriaId(e.target.value)}
+              disabled={lataaKategoriat}
+            >
+              <option value="">Ei kategoriaa</option>
+              {kategoriat.map((k) => (
+                <option key={k.id} value={k.id}>{k.nimi}</option>
+              ))}
+            </select>
+          </div>
+
+          {virhe && <p style={{ color: "red" }}>{virhe}</p>}
+          {onnistui && <p style={{ color: "green" }}>Tulo lisätty!</p>}
+
+          <button type="submit" disabled={lahettaa}>
+            {lahettaa ? "Tallennetaan..." : "Lisää tulo"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/main/java/fi/opiskelijan/budjettilaskuri/web/TuloController.java
+++ b/src/main/java/fi/opiskelijan/budjettilaskuri/web/TuloController.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -28,12 +27,13 @@ public class TuloController {
         model.addAttribute("kategoriat", kategoriaRepository.findAll());
         return "lisaa-tulo";
     }
-
+    /* Kommentoitu pois — React-frontend käyttää TuloRestController-luokan endpointia
     @PostMapping("/api/tulot")
     public String lisaaTulo(@ModelAttribute Tulo tulo) {
         tuloRepository.save(tulo);
         return "redirect:/tulot";
     }
+    */
 
     @PostMapping("/tulot/{id}/poista")
     public String poistaTulo(@PathVariable Long id) {

--- a/src/main/java/fi/opiskelijan/budjettilaskuri/web/TuloRestController.java
+++ b/src/main/java/fi/opiskelijan/budjettilaskuri/web/TuloRestController.java
@@ -1,12 +1,17 @@
 package fi.opiskelijan.budjettilaskuri.web;
 
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 import fi.opiskelijan.budjettilaskuri.domain.Tulo;
-import fi.opiskelijan.budjettilaskuri.domain.TuloRepository;
+import fi.opiskelijan.budjettilaskuri.repository.TuloRepository;
 
 @RestController
 @RequestMapping("/api/tulot")
@@ -18,5 +23,11 @@ public class TuloRestController {
     @GetMapping
     public List<Tulo> getAll() {
         return tuloRepository.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<Tulo> lisaaTulo(@RequestBody Tulo tulo) {
+        Tulo tallennettu = tuloRepository.save(tulo);
+        return ResponseEntity.status(201).body(tallennettu);
     }
 }


### PR DESCRIPTION
- Lisätty TuloRestController, ottaa vastaan tulon JSON-muodossa ja tallentaa sen tietokantaan
- Kommentoitu pois TuloControllerin vanha POST /api/tulot -metodi, vanha toimi Thymeleafin kanssa, mutta ei Reactilla
- Luotu tuloApi.js, hoitaa kommunikaation backendin kanssa (kategorioiden haku ja tulon tallennus)
- Toteutettu LisaaTapahtuma.jsx eli lomake jolla käyttäjä voi lisätä uuden tulon